### PR TITLE
Update FederatedTransitDataBundleCreatorMain.java

### DIFF
--- a/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/FederatedTransitDataBundleCreatorMain.java
+++ b/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/FederatedTransitDataBundleCreatorMain.java
@@ -230,6 +230,7 @@ public class FederatedTransitDataBundleCreatorMain {
   }
 
   protected void buildOptions(Options options) {
+    options.addOption(ARG_USE_DATABASE_FOR_GTFS, false, "");
     options.addOption(ARG_SKIP_TO, true, "");
     options.addOption(ARG_ONLY, true, "");
     options.addOption(ARG_SKIP, true, "");


### PR DESCRIPTION
The ARG_USE_DATABASE_FOR_GTFS option was not added to the Options, so every user making use of this argument went through a bothering error.
